### PR TITLE
Tuning library for openai

### DIFF
--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -351,15 +351,19 @@ class OListProcessor(BlockProcessor):
 
         if sibling is not None and sibling.tag in self.SIBLING_TAGS:
             subsibling = self.lastChild(sibling)
+            if subsibling is not None:
+                subsubsibling = self.lastChild(subsibling)
+            else:
+                subsubsibling = None
             if sibling.tag == self.TAG or (
-                    subsibling is not None and subsibling.tag in self.SIBLING_TAGS
+                    subsubsibling is not None and subsubsibling.tag in self.SIBLING_TAGS
             ):
                 if sibling.tag == self.TAG:
                     # Previous block was a list item, so set that as parent
                     lst = sibling
                 else:
                     # subsibling was a list item, so set that as parent
-                    lst = subsibling
+                    lst = subsubsibling
                 # make sure previous item is in a p- if the item has text,
                 # then it isn't in a p
                 if lst[-1].text:
@@ -384,11 +388,11 @@ class OListProcessor(BlockProcessor):
                 firstitem = items.pop(0)
                 self.parser.parseBlocks(li, [firstitem])
                 self.parser.state.reset()
-            else:
+            elif subsibling is not None:
                 # if the list is not indented, but suddenly - there's a different TAG
                 # that is supposed to be generated (ul changes to ol or ol changes to
                 # ul) - assume that
-                lst = etree.SubElement(sibling, self.TAG)
+                lst = etree.SubElement(subsibling, self.TAG)
                 # Check if a custom start integer is set
                 if not self.LAZY_OL and self.STARTSWITH != '1':
                     lst.attrib['start'] = self.STARTSWITH

--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -335,10 +335,10 @@ class OListProcessor(BlockProcessor):
         # Detect an item (``1. item``). ``group(1)`` contains contents of item.
         self.RE = re.compile(r'^[ ]{0,%d}\d+\.[ ]+(.*)' % (self.tab_length - 1))
         # Detect items on secondary lines. they can be of either list type.
-        self.CHILD_RE = re.compile(r'^[ ]{0,%d}((\d+\.)|[*+-])[ ]+(.*)' %
+        self.CHILD_RE = re.compile(r'^[ ]{0,%d}((\d+\.)|[*+-•])[ ]+(.*)' %
                                    (self.tab_length - 1))
         # Detect indented (nested) items of either type
-        self.INDENT_RE = re.compile(r'^[ ]{%d,%d}((\d+\.)|[*+-])[ ]+.*' %
+        self.INDENT_RE = re.compile(r'^[ ]{%d,%d}((\d+\.)|[*+-•])[ ]+.*' %
                                     (self.tab_length, self.tab_length * 2 - 1))
 
     def test(self, parent, block):
@@ -438,7 +438,7 @@ class UListProcessor(OListProcessor):
     def __init__(self, parser):
         super().__init__(parser)
         # Detect an item (``1. item``). ``group(1)`` contains contents of item.
-        self.RE = re.compile(r'^[ ]{0,%d}[*+-][ ]+(.*)' % (self.tab_length - 1))
+        self.RE = re.compile(r'^[ ]{0,%d}[*+-•][ ]+(.*)' % (self.tab_length - 1))
 
 
 class HashHeaderProcessor(BlockProcessor):

--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -335,10 +335,10 @@ class OListProcessor(BlockProcessor):
         # Detect an item (``1. item``). ``group(1)`` contains contents of item.
         self.RE = re.compile(r'^[ ]{0,%d}\d+\.[ ]+(.*)' % (self.tab_length - 1))
         # Detect items on secondary lines. they can be of either list type.
-        self.CHILD_RE = re.compile(r'^[ ]{0,%d}((\d+\.)|[*+-•])[ ]+(.*)' %
+        self.CHILD_RE = re.compile(r'^[ ]{0,%d}((\d+\.)|[*+-])[ ]+(.*)' %
                                    (self.tab_length - 1))
         # Detect indented (nested) items of either type
-        self.INDENT_RE = re.compile(r'^[ ]{%d,%d}((\d+\.)|[*+-•])[ ]+.*' %
+        self.INDENT_RE = re.compile(r'^[ ]{%d,%d}((\d+\.)|[*+-])[ ]+.*' %
                                     (self.tab_length, self.tab_length * 2 - 1))
 
     def test(self, parent, block):
@@ -448,14 +448,12 @@ class OListProcessor(BlockProcessor):
 
 class UListProcessor(OListProcessor):
     """ Process unordered list blocks. """
-
     TAG = 'ul'
-    SIBLING_TAGS = ['ol', 'ul']
 
     def __init__(self, parser):
         super().__init__(parser)
         # Detect an item (``1. item``). ``group(1)`` contains contents of item.
-        self.RE = re.compile(r'^[ ]{0,%d}[*+-•][ ]+(.*)' % (self.tab_length - 1))
+        self.RE = re.compile(r'^[ ]{0,%d}[*+-][ ]+(.*)' % (self.tab_length - 1))
 
 
 class HashHeaderProcessor(BlockProcessor):

--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -328,7 +328,7 @@ class OListProcessor(BlockProcessor):
     # Lazy ol - ignore startswith
     LAZY_OL = True
     # List of allowed sibling tags.
-    SIBLING_TAGS = ['ol']
+    SIBLING_TAGS = ['ol', 'ul']
 
     def __init__(self, parser):
         super().__init__(parser)
@@ -349,33 +349,34 @@ class OListProcessor(BlockProcessor):
         items = self.get_items(blocks.pop(0))
         sibling = self.lastChild(parent)
 
-        if sibling is not None and sibling.tag in self.SIBLING_TAGS:
-            # Previous block was a list item, so set that as parent
-            lst = sibling
-            # make sure previous item is in a p- if the item has text,
-            # then it isn't in a p
-            if lst[-1].text:
-                # since it's possible there are other children for this
-                # sibling, we can't just SubElement the p, we need to
-                # insert it as the first item.
-                p = etree.Element('p')
-                p.text = lst[-1].text
-                lst[-1].text = ''
-                lst[-1].insert(0, p)
-            # if the last item has a tail, then the tail needs to be put in a p
-            # likely only when a header is not followed by a blank line
-            lch = self.lastChild(lst[-1])
-            if lch is not None and lch.tail:
-                p = etree.SubElement(lst[-1], 'p')
-                p.text = lch.tail.lstrip()
-                lch.tail = ''
+        if sibling is not None:
+            if sibling.tag == self.TAG:
+                # Previous block was a list item, so set that as parent
+                lst = sibling
+                # make sure previous item is in a p- if the item has text,
+                # then it isn't in a p
+                if lst[-1].text:
+                    # since it's possible there are other children for this
+                    # sibling, we can't just SubElement the p, we need to
+                    # insert it as the first item.
+                    p = etree.Element('p')
+                    p.text = lst[-1].text
+                    lst[-1].text = ''
+                    lst[-1].insert(0, p)
+                # if the last item has a tail, then the tail needs to be put in a p
+                # likely only when a header is not followed by a blank line
+                lch = self.lastChild(lst[-1])
+                if lch is not None and lch.tail:
+                    p = etree.SubElement(lst[-1], 'p')
+                    p.text = lch.tail.lstrip()
+                    lch.tail = ''
 
-            # parse first block differently as it gets wrapped in a p.
-            li = etree.SubElement(lst, 'li')
-            self.parser.state.set('looselist')
-            firstitem = items.pop(0)
-            self.parser.parseBlocks(li, [firstitem])
-            self.parser.state.reset()
+                # parse first block differently as it gets wrapped in a p.
+                li = etree.SubElement(lst, 'li')
+                self.parser.state.set('looselist')
+                firstitem = items.pop(0)
+                self.parser.parseBlocks(li, [firstitem])
+                self.parser.state.reset()
         elif parent.tag in ['ol', 'ul']:
             # this catches the edge case of a multi-item indented list whose
             # first item is in a blank parent-list item:

--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -328,7 +328,7 @@ class OListProcessor(BlockProcessor):
     # Lazy ol - ignore startswith
     LAZY_OL = True
     # List of allowed sibling tags.
-    SIBLING_TAGS = ['ol', 'ul']
+    SIBLING_TAGS = ['ol']
 
     def __init__(self, parser):
         super().__init__(parser)
@@ -434,6 +434,7 @@ class UListProcessor(OListProcessor):
     """ Process unordered list blocks. """
 
     TAG = 'ul'
+    SIBLING_TAGS = ['ul']
 
     def __init__(self, parser):
         super().__init__(parser)

--- a/markdown/core.py
+++ b/markdown/core.py
@@ -30,7 +30,7 @@ from .treeprocessors import build_treeprocessors
 from .inlinepatterns import build_inlinepatterns
 from .postprocessors import build_postprocessors
 from .extensions import Extension
-from .serializers import to_html_string, to_xhtml_string
+from .serializers import to_html_string, to_xhtml_string, to_sweetprocess_string
 from .util import BLOCK_LEVEL_ELEMENTS
 
 __all__ = ['Markdown', 'markdown', 'markdownFromFile']
@@ -47,6 +47,7 @@ class Markdown:
     output_formats = {
         'html':   to_html_string,
         'xhtml':  to_xhtml_string,
+        'sweetprocess': to_sweetprocess_string,
     }
 
     def __init__(self, **kwargs):

--- a/markdown/core.py
+++ b/markdown/core.py
@@ -71,7 +71,7 @@ class Markdown:
         self.tab_length = kwargs.get('tab_length', 4)
 
         self.ESCAPED_CHARS = ['\\', '`', '*', '_', '{', '}', '[', ']',
-                              '(', ')', '>', '#', '+', '-', '.', '!']
+                              '(', ')', '>', '#', '+', '-', '.', '!', '•']
 
         self.block_level_elements = BLOCK_LEVEL_ELEMENTS.copy()
 

--- a/markdown/core.py
+++ b/markdown/core.py
@@ -78,7 +78,7 @@ class Markdown:
 
         self.registeredExtensions = []
         self.docType = ""
-        self.stripTopLevelTags = True
+        self.stripTopLevelTags = False
 
         self.build_parser()
 

--- a/markdown/preprocessors.py
+++ b/markdown/preprocessors.py
@@ -35,6 +35,7 @@ def build_preprocessors(md, **kwargs):
     preprocessors = util.Registry()
     preprocessors.register(NormalizeWhitespace(md), 'normalize_whitespace', 30)
     preprocessors.register(HtmlBlockPreprocessor(md), 'html_block', 20)
+    preprocessors.register(ListReformatPreprocessor(md), 'list_reformat', 20)
     return preprocessors
 
 
@@ -57,6 +58,15 @@ class Preprocessor(util.Processor):
 
         """
         pass  # pragma: no cover
+
+
+class ListReformatPreprocessor(Preprocessor):
+    """ Normalize whitespace for consistent parsing. """
+
+    def run(self, lines):
+        source = '\n'.join(lines)
+        source = source.replace('•', "+")
+        return source.split('\n')
 
 
 class NormalizeWhitespace(Preprocessor):

--- a/markdown/serializers.py
+++ b/markdown/serializers.py
@@ -187,3 +187,7 @@ def to_html_string(element):
 
 def to_xhtml_string(element):
     return _write_html(ElementTree(element).getroot(), format="xhtml")
+
+
+def to_sweetprocess_string(element):
+    return _write_html(ElementTree(element).getroot(), format="html")

--- a/markdown/serializers.py
+++ b/markdown/serializers.py
@@ -175,7 +175,6 @@ def _write_html(root, format="html"):
     data = []
     write = data.append
     _serialize_html(write, root, format)
-    print(data)
     return "".join(data)
 
 
@@ -210,6 +209,7 @@ def _unwrap_text(element):
     else:
         return ''.join(_unwrap_text(e) for e in element)
 
+
 sentence_regex = re.compile(r"(?<=\w\.\.\. )|(?<=\w\. )|(?<=\w\? )|(?<=\w! )|(?<=\w: )")
 
 
@@ -225,18 +225,26 @@ def _generate_step_from_xml(element, n):
 
         return step(title, content, n)
     else:
-        title = _unwrap_text(element[0])
+        text = _unwrap_text(element[0])
+
+        sentences = sentence_regex.split(text)
+        title = f"{sentences[0]}".strip()
+        if title.endswith(":"):
+            title = title[: (len(title) - 1)]
+        content = "".join(sentences[1:])
+
         data = []
         write = data.append
         for e in element[1:]:
             _serialize_html(write, e, 'html')
-        content = ''.join(data).replace('\n', '')
+        html_content = ''.join(data).replace('\n', '')
+        content = f"{content} {html_content}"
         return step(title, content, n)
 
 
 def _write_steps(write, element):
     for i, e in enumerate(element):
-        write(_generate_step_from_xml(e, i))
+        write(_generate_step_from_xml(e, i + 1))
 
 
 def _write_sweetprocess(element):

--- a/markdown/serializers.py
+++ b/markdown/serializers.py
@@ -214,7 +214,7 @@ sentence_regex = re.compile(r"(?<=\w\.\.\. )|(?<=\w\. )|(?<=\w\? )|(?<=\w! )|(?<
 
 
 def _generate_step_from_xml(element, n):
-    if len(element) == 1:
+    if len(element) <= 1:
         text = _unwrap_text(element)
         sentences = sentence_regex.split(text)
 
@@ -242,21 +242,22 @@ def _generate_step_from_xml(element, n):
         return step(title, content, n)
 
 
-def _write_steps(write, element):
-    for i, e in enumerate(element):
-        write(_generate_step_from_xml(e, i + 1))
+def _write_steps(write, element, i_offset):
+    if len(element) <= 1:
+        write(_generate_step_from_xml(element, 1 + i_offset))
+    else:
+        for i, e in enumerate(element):
+            write(_generate_step_from_xml(e, i + 1 + i_offset))
 
 
 def _write_sweetprocess(element):
     data = []
     write = data.append
-    for e in element:
-        _write_steps(write, e)
+    for i, e in enumerate(element):
+        _write_steps(write, e, i)
     return data
 
 
 def to_sweetprocess_string(element):
     data = _write_sweetprocess(ElementTree(element).getroot())
-    from pprint import pprint
-    pprint(data)
     return json.dumps(data)

--- a/tests/test_sweetprocess.py
+++ b/tests/test_sweetprocess.py
@@ -1,5 +1,7 @@
+import json
 import unittest
 import markdown
+from pprint import pprint
 
 test_text = """
 \n\n1. Introduce yourself and explain the purpose of the interview.\n\n2. Outline the general structure of the interview and explain that the participant is free to elaborate on any point they feel is important.\n\n3. Ask open-ended questions about the participant's experience of walking as a child. Questions may include:\n\n• What were your favorite walking destinations as a child?\n\n• How did walking make you feel?\n\n• What did you think about while walking?\n\n• What were the most memorable walking experiences you had as a child?\n\n• What was your relationship with walking as a child?\n\n• How did you and your family use walking as a mode of transportation?\n\n4. Ask follow-up questions to further explore the participant's experience.\n\n5. Thank the participant for their time.
@@ -14,10 +16,10 @@ class TestSweetprocess(unittest.TestCase):
 
     def test_sample_list_text(self):
         # print(self.md.convert(test_text.replace('•', '  •')))
-        print(self.md.convert(test_text))
+        pprint(json.loads(self.md.convert(test_text)))
 
     def test_wrapped_unindented_list_text(self):
-        print(self.md.convert("""
+        pprint(json.loads(self.md.convert("""
         \n\nYou might want to start with this:
         \n\n1. one
         \n\n2. two
@@ -27,14 +29,14 @@ class TestSweetprocess(unittest.TestCase):
         \n\nThen you migth want to do this:
         \n\n1. this
         \n\n2. that
-        """))
+        """)))
 
     def test_weird_stuff(self):
-        print(self.md.convert("""
+        pprint(json.loads(self.md.convert("""
         \n\nThis & that.
         \n\n
         \n\n4 < 5.
         \n\n
         \n\n6 > 5.
         \n\n
-        """))
+        """)))

--- a/tests/test_sweetprocess.py
+++ b/tests/test_sweetprocess.py
@@ -10,7 +10,7 @@ class TestSweetprocess(unittest.TestCase):
 
     def setUp(self):
         """ Create instance of Markdown. """
-        self.md = markdown.Markdown()
+        self.md = markdown.Markdown(output_format='sweetprocess')
 
     def test_sample_list_text(self):
         # print(self.md.convert(test_text.replace('•', '  •')))

--- a/tests/test_sweetprocess.py
+++ b/tests/test_sweetprocess.py
@@ -1,0 +1,16 @@
+import unittest
+import markdown
+
+test_text = """
+\n\n1. Introduce yourself and explain the purpose of the interview.\n\n2. Outline the general structure of the interview and explain that the participant is free to elaborate on any point they feel is important.\n\n3. Ask open-ended questions about the participant's experience of walking as a child. Questions may include:\n\n• What were your favorite walking destinations as a child?\n\n• How did walking make you feel?\n\n• What did you think about while walking?\n\n• What were the most memorable walking experiences you had as a child?\n\n• What was your relationship with walking as a child?\n\n• How did you and your family use walking as a mode of transportation?\n\n4. Ask follow-up questions to further explore the participant's experience.\n\n5. Thank the participant for their time.
+"""
+
+class TestSweetprocess(unittest.TestCase):
+    """ Tests basics of the Markdown class. """
+
+    def setUp(self):
+        """ Create instance of Markdown. """
+        self.md = markdown.Markdown(tab_length=2)
+
+    def test_sample_text(self):
+        print(self.md.convert(test_text.replace('•', '  •')))

--- a/tests/test_sweetprocess.py
+++ b/tests/test_sweetprocess.py
@@ -10,7 +10,21 @@ class TestSweetprocess(unittest.TestCase):
 
     def setUp(self):
         """ Create instance of Markdown. """
-        self.md = markdown.Markdown(tab_length=2)
+        self.md = markdown.Markdown()
 
-    def test_sample_text(self):
-        print(self.md.convert(test_text.replace('•', '  •')))
+    def test_sample_list_text(self):
+        # print(self.md.convert(test_text.replace('•', '  •')))
+        print(self.md.convert(test_text))
+
+    def test_wrapped_unindented_list_text(self):
+        print(self.md.convert("""
+        \n\nYou might want to start with this:
+        \n\n1. one
+        \n\n2. two
+        \n\nWhat is going on in here? I have no idea what is going on here.
+        \n\n- two
+        \n\n* three
+        \n\nThen you migth want to do this:
+        \n\n1. this
+        \n\n2. that
+        """))

--- a/tests/test_sweetprocess.py
+++ b/tests/test_sweetprocess.py
@@ -28,3 +28,13 @@ class TestSweetprocess(unittest.TestCase):
         \n\n1. this
         \n\n2. that
         """))
+
+    def test_weird_stuff(self):
+        print(self.md.convert("""
+        \n\nThis & that.
+        \n\n
+        \n\n4 < 5.
+        \n\n
+        \n\n6 > 5.
+        \n\n
+        """))


### PR DESCRIPTION
@jtrain - just a mention for you here so you know what I'm doing with the lib. My intentions right now are:

- write my own output formatted (no monkey-patching needed)
- Adding that ``•`` character to markdown parser (might infolve monkey-patching, but it's not needed - I will be aiming to run a ``replace`` or even writing my own preprocessor
- Changing how ``ListIndentProcessor`` is working - and for that - I think I will need some monkey-patching. Why do I even do it? well, this is because one annoying thing is this thing that I need to do in the test case: ``test_text.replace('•', '  •')``.  If I don't do it, current markdown processor thinks that the unordered list ``dots`` are continuation of ordered list numbering. This is annoying, I strongly feel that this can be reformatted in a more sensible way. It has the numbering, it can KNOW that this unordered list is a sub-list of an ordered list.

I believe all of this is possible to do.